### PR TITLE
Feat: negate spell

### DIFF
--- a/Classes/src/sorcerer.adoc
+++ b/Classes/src/sorcerer.adoc
@@ -2,27 +2,27 @@
 
 [width="100%",cols="8%,6%,61%,8%,7%,10%",options="header",]
 |===
-|*_Level_* |*_Prof. Bonus_* |*_Features_* a                                        | *_Cantrips Known_* |*_Spell Points_* a| *_Max. Spell Level_*
-|*1st*     |*+2*            |*Spellcasting, Sorcerous Origin*                      |*4* |*4* |*1st*
-|*2nd*     |*+2*            |*Metamagic*                                           |*4* |*6* |*1st*
-|*3rd*     |*+2*            |*Magical Guidance*                                    |*4* |*14* |*2nd*
-|*4th*     |*+2*            |*Feat*                                                |*5* |*17* |*2nd*
+|*_Level_* |*_Prof. Bonus_* |*_Features_* a                                                      | *_Cantrips Known_* |*_Spell Points_* a| *_Max. Spell Level_*
+|*1st*     |*+2*            |*Spellcasting, Sorcerous Origin*                                    |*4* |*4* |*1st*
+|*2nd*     |*+2*            |*Metamagic*                                                         |*4* |*6* |*1st*
+|*3rd*     |*+2*            |*Magical Guidance*                                                  |*4* |*14* |*2nd*
+|*4th*     |*+2*            |*Feat*                                                              |*5* |*17* |*2nd*
 |*5th*     |*+3*            |*Sorcerous Restoration (1d6), Sorcerous Vitality*,*Negate Spell*    |*5* |*27* |*3rd*
-|*6th*     |*+3*            |*Sorcerous Origin feature*                            |*5* |*32* |*3rd*
-|*7th*     |*+3*            |*Arcane Eruption, Metamagic*                          |*5* |*38* |*4th*
-|*8th*     |*+3*            |*Feat*                                                |*5* |*44* |*4th*
-|*9th*     |*+4*            |*Arcane Secrets, Sorcerous Vitality Improvement*      |*5* |*57* |*5th*
-|*10th*    |*+4*            |*Sorcery Incarnate*                                   |*6* |*64* |*5th*
-|*11th*    |*+4*            |*Metamagic, Sorcerous Restoration Improvement (1d12)* |*6* |*73* |*6th*
-|*12th*    |*+4*            |*Feat*                                                |*6* |*73* |*6th* 
-|*13th*    |*+5*            |*Arcane Secrets*                                      |*6* |*83* |*7th*
-|*14th*    |*+5*            |*Sorcerous Origin feature*                            |*6* |*83* |*7th*
-|*15th*    |*+5*            |*Arcane Secrets, Metamagic*                           |*6* |*94* |*8th*
-|*16th*    |*+5*            |*Feat*                                                |*6* |*94* |*8th*
-|*17th*    |*+6*            |*Sorcerous Restoration Improvement (2d12)*            |*6* |*107* |*9th*
-|*18th*    |*+6*            |*Metamagic*                                           |*6* |*114* |*9th*
-|*19th*    |*+6*            |*Feat*                                                |*6* |*123* |*9th*
-|*20th*    |*+6*            |*Arcone Apotheosis*                                   |*6* |*133* |*9th*
+|*6th*     |*+3*            |*Sorcerous Origin feature*                                          |*5* |*32* |*3rd*
+|*7th*     |*+3*            |*Arcane Eruption, Metamagic*                                        |*5* |*38* |*4th*
+|*8th*     |*+3*            |*Feat*                                                              |*5* |*44* |*4th*
+|*9th*     |*+4*            |*Arcane Secrets, Sorcerous Vitality Improvement*                    |*5* |*57* |*5th*
+|*10th*    |*+4*            |*Sorcery Incarnate*                                                 |*6* |*64* |*5th*
+|*11th*    |*+4*            |*Metamagic, Sorcerous Restoration Improvement (1d12)*               |*6* |*73* |*6th*
+|*12th*    |*+4*            |*Feat*                                                              |*6* |*73* |*6th* 
+|*13th*    |*+5*            |*Arcane Secrets*                                                    |*6* |*83* |*7th*
+|*14th*    |*+5*            |*Sorcerous Origin feature*                                          |*6* |*83* |*7th*
+|*15th*    |*+5*            |*Arcane Secrets, Metamagic*                                         |*6* |*94* |*8th*
+|*16th*    |*+5*            |*Feat*                                                              |*6* |*94* |*8th*
+|*17th*    |*+6*            |*Sorcerous Restoration Improvement (2d12)*                          |*6* |*107* |*9th*
+|*18th*    |*+6*            |*Metamagic*                                                         |*6* |*114* |*9th*
+|*19th*    |*+6*            |*Feat*                                                              |*6* |*123* |*9th*
+|*20th*    |*+6*            |*Arcone Apotheosis*                                                 |*6* |*133* |*9th*
 |===
 
 [width="99%"]

--- a/Classes/src/sorcerer.adoc
+++ b/Classes/src/sorcerer.adoc
@@ -7,7 +7,7 @@
 |*2nd*     |*+2*            |*Metamagic*                                           |*4* |*6* |*1st*
 |*3rd*     |*+2*            |*Magical Guidance*                                    |*4* |*14* |*2nd*
 |*4th*     |*+2*            |*Feat*                                                |*5* |*17* |*2nd*
-|*5th*     |*+3*            |*Sorcerous Restoration (1d6), Sorcerous Vitality*     |*5* |*27* |*3rd*
+|*5th*     |*+3*            |*Sorcerous Restoration (1d6), Sorcerous Vitality*,*Negate Spell*    |*5* |*27* |*3rd*
 |*6th*     |*+3*            |*Sorcerous Origin feature*                            |*5* |*32* |*3rd*
 |*7th*     |*+3*            |*Arcane Eruption, Metamagic*                          |*5* |*38* |*4th*
 |*8th*     |*+3*            |*Feat*                                                |*5* |*44* |*4th*
@@ -299,6 +299,21 @@ number of d6 is your proficiency bonus.
 
 You can use this trait once, and you use it again when you finish a
 Short or Long Rest.
+
+=== *Negate Spell*
+At 5th level, you are able to stop the casting of a spell.
+As a reaction, when you see someone casting a spell withing 60 feet from you, you can try
+to cancel the casting. 
+
+To be eligeable as a correct target the target spell must have, at least, one component. 
+
+You can negate all spells that are equal or lower than the maximum spell level that you 
+are able to cast from this class. If the spell is higher, the caster target must succed 
+on a Constitution saving throw to be able to cast the spell, on a failure the spell is 
+negated. The DC for this save it your spell save DC from this class.
+
+You can use this feature a number of time equals to your Proficiency Bonus and regain all spent uses 
+after a Long Rest.
 
 === *Sorcerous Origin feature*
 

--- a/Classes/src/warlock.adoc
+++ b/Classes/src/warlock.adoc
@@ -7,7 +7,7 @@
 |*2nd*      |*+2*             |*Eldritch Invocations*        |*2*                |*3*              |*1*             |*1st*          |*2*
 |*3rd*      |*+2*             |*Otherworldly Patron*         |*2*                |*4*              |*1*             |*2nd*          |*2*
 |*4th*      |*+2*             |*Feat, Eldritch Versatility*  |*3*                |*5*              |*1*             |*2nd*          |*2*
-|*5th*      |*+3*             |*—*                           |*3*                |*6*              |*2*             |*3rd*          |*3*
+|*5th*      |*+3*             |*Negate Spell*                |*3*                |*6*              |*2*             |*3rd*          |*3*
 |*6th*      |*+3*             |*Otherworldly Patron feature* |*3*                |*7*              |*2*             |*3rd*          |*3*
 |*7th*      |*+3*             |*—*                           |*3*                |*8*              |*2*             |*4th*          |*4*
 |*8th*      |*+3*             |*Feat*                        |*3*                |*9*              |*2*             |*4th*          |*4*
@@ -398,6 +398,21 @@ ____
 If this change makes you ineligible for any of your Eldritch
 Invocations, you must also replace them now, choosing invocations for
 which you qualify.
+
+=== *Negate Spell*
+At 5th level, you are able to stop the casting of a spell.
+As a reaction, when you see someone casting a spell withing 60 feet from you, you can try
+to cancel the casting. 
+
+To be eligeable as a correct target the target spell must have, at least, one component. 
+
+You can negate all spells that are equal or lower than the maximum spell level that you 
+are able to cast from this class. If the spell is higher, the caster target must succed 
+on a Constitution saving throw to be able to cast the spell, on a failure the spell is 
+negated. The DC for this save it your spell save DC from this class.
+
+You can use this feature a number of time equals to your Proficiency Bonus and regain all spent uses 
+after a Long Rest.
 
 === *Otherworldly Patron feature*
 

--- a/Classes/src/wizard.adoc
+++ b/Classes/src/wizard.adoc
@@ -8,7 +8,7 @@
 |*2nd*      |*+2*            |*Arcane Recovery, Cantrip Formulas* |*3*                |*3*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*
 |*3rd*      |*+2*            |*Arcane Tradition*                  |*3*                |*4*     |*2*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*
 |*4th*      |*+2*            |*Feat*                              |*4*                |*4*     |*3*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*
-|*5th*      |*+3*            |*School Savant*                     |*4*                |*4*     |*3*     |*2*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*
+|*5th*      |*+3*            |*School Savant*,*Negate Spell*      |*4*                |*4*     |*3*     |*2*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*
 |*6th*      |*+3*            |*Arcane Tradition feature*          |*4*                |*4*     |*3*     |*3*     |*—*     |*—*     |*—*     |*—*     |*—*     |*—*
 |*7th*      |*+3*            |*—*                                 |*4*                |*4*     |*3*     |*3*     |*1*     |*—*     |*—*     |*—*     |*—*     |*—*
 |*8th*      |*+3*            |*Feat*                              |*4*                |*4*     |*3*     |*3*     |*2*     |*—*     |*—*     |*—*     |*—*     |*—*
@@ -264,6 +264,21 @@ ____
 
 Additionally, you can’t lose the spells that are from your School of
 magic.
+
+=== *Negate Spell*
+At 5th level, you are able to stop the casting of a spell.
+As a reaction, when you see someone casting a spell withing 60 feet from you, you can try
+to cancel the casting. 
+
+To be eligeable as a correct target the target spell must have, at least, one component. 
+
+You can negate all spells that are equal or lower than the maximum spell level that you 
+are able to cast from this class. If the spell is higher, the caster target must succed 
+on a Constitution saving throw to be able to cast the spell, on a failure the spell is 
+negated. The DC for this save it your spell save DC from this class.
+
+You can use this feature a number of time equals to your Proficiency Bonus and regain all spent uses 
+after a Long Rest.
 
 === *Arcane Tradition feature*
 


### PR DESCRIPTION
Counterspell as a spell is a complete mess, our approach is to make it a class feature, only for the Arcane full spell casters (Sorcerer, Warlock and Wizard). It's a Constitution saving throw allowing targets to use special traits related to salvations.